### PR TITLE
Add the ability to download and manage Fallout 3 mods

### DIFF
--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -83,7 +83,7 @@ QString GameFalloutNV::description() const
 
 MOBase::VersionInfo GameFalloutNV::version() const
 {
-  return VersionInfo(1, 3, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 4, 0, VersionInfo::RELEASE_FINAL);
 }
 
 bool GameFalloutNV::isActive() const
@@ -143,6 +143,11 @@ QStringList GameFalloutNV::primaryPlugins() const
 QString GameFalloutNV::gameShortName() const
 {
   return "FalloutNV";
+}
+
+QStringList GameFalloutNV::validShortNames() const
+{
+  return { "Fallout3" };
 }
 
 QString GameFalloutNV::gameNexusName() const

--- a/src/gamefalloutnv.h
+++ b/src/gamefalloutnv.h
@@ -30,6 +30,7 @@ public: // IPluginGame interface
   virtual QString steamAPPId() const override;
   virtual QStringList primaryPlugins() const override;
   virtual QString gameShortName() const override;
+  virtual QStringList validShortNames() const override;
   virtual QString gameNexusName() const override;
   virtual QStringList iniFiles() const override;
   virtual QStringList DLCPlugins() const override;


### PR DESCRIPTION
This has been requested a few times in the past.  One example of usage is [Fear and Loathing in New Vegas](https://wiki.step-project.com/User:EssArrBee/FalloutNewVegas) which uses the Fallout 3 Weapon Enhancement Pack.