### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -100,7 +100,7 @@ QString GameFalloutNV::description() const
 
 MOBase::VersionInfo GameFalloutNV::version() const
 {
-  return VersionInfo(1, 4, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameFalloutNV::settings() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -153,7 +153,19 @@ QString GameFalloutNV::steamAPPId() const
 
 QStringList GameFalloutNV::primaryPlugins() const
 {
-  return { "falloutnv.esm" };
+  QStringList plugins = { "falloutnv.esm" };
+
+  // DLC are force-loaded through .NAM files so look for those
+  for (QString dlcFile : DLCPlugins())
+  {
+    QString namFile = dlcFile.toLower().replace(".esm", ".nam");
+    if (dataDirectory().exists(namFile))
+    {
+        plugins << dlcFile;
+    }
+  }
+
+  return plugins;
 }
 
 QString GameFalloutNV::gameShortName() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -112,7 +112,6 @@ void GameFalloutNV::initializeProfile(const QDir &path, ProfileSettings settings
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/FalloutNV", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/FalloutNV", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.