### PR TITLE
KEYWORDS and BaseObjectSwapper valid folders.

### DIFF
--- a/src/falloutnvmoddatachecker.h
+++ b/src/falloutnvmoddatachecker.h
@@ -11,12 +11,15 @@ public:
 protected:
   virtual const FileNameSet& possibleFolderNames() const override
   {
-    static FileNameSet result{
-        "fonts",      "interface",  "menus",         "meshes",    "music",
-        "scripts",    "shaders",    "sound",         "strings",   "textures",
-        "trees",      "video",      "facegen",       "materials", "nvse",
-        "distantlod", "asi",        "Tools",         "MCM",       "distantland",
-        "mits",       "dllplugins", "CalienteTools", "shadersfx", "config"};
+    static FileNameSet result{"fonts",      "interface",     "menus",
+                              "meshes",     "music",         "scripts",
+                              "shaders",    "sound",         "strings",
+                              "textures",   "trees",         "video",
+                              "facegen",    "materials",     "nvse",
+                              "distantlod", "asi",           "Tools",
+                              "MCM",        "distantland",   "mits",
+                              "dllplugins", "CalienteTools", "shadersfx",
+                              "config",     "KEYWORDS",      "BaseObjectSwapper"};
     return result;
   }
   virtual const FileNameSet& possibleFileExtensions() const override

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -218,7 +218,6 @@ void GameFalloutNV::initializeProfile(const QDir& path, ProfileSettings settings
 
     copyToProfile(myGamesPath(), path, "falloutprefs.ini");
     copyToProfile(myGamesPath(), path, "falloutcustom.ini");
-    copyToProfile(myGamesPath(), path, "custom.ini");
     copyToProfile(myGamesPath(), path, "GECKCustom.ini");
     copyToProfile(myGamesPath(), path, "GECKPrefs.ini");
   }
@@ -272,8 +271,8 @@ QString GameFalloutNV::gameNexusName() const
 
 QStringList GameFalloutNV::iniFiles() const
 {
-  return {"fallout.ini", "falloutprefs.ini", "falloutcustom.ini",
-          "custom.ini",  "GECKCustom.ini",   "GECKPrefs.ini"};
+  return {"fallout.ini", "falloutprefs.ini", "falloutcustom.ini", "GECKCustom.ini",
+          "GECKPrefs.ini"};
 }
 
 QStringList GameFalloutNV::DLCPlugins() const


### PR DESCRIPTION
This allows KEYWORDS and BaseObjectSwapper folders to be recognized as valid to support their respective mods.