### PR TITLE
Change Construction Kit to GECK

### DIFF
--- a/src/game_falloutNV_en.ts
+++ b/src/game_falloutNV_en.ts
@@ -4,12 +4,12 @@
 <context>
     <name>GameFalloutNV</name>
     <message>
-        <location filename="gamefalloutnv.cpp" line="165"/>
+        <location filename="gamefalloutnv.cpp" line="179"/>
         <source>Fallout NV Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutnv.cpp" line="175"/>
+        <location filename="gamefalloutnv.cpp" line="189"/>
         <source>Adds support for the game Fallout New Vegas</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/game_falloutNV_en.ts
+++ b/src/game_falloutNV_en.ts
@@ -4,12 +4,12 @@
 <context>
     <name>GameFalloutNV</name>
     <message>
-        <location filename="gamefalloutnv.cpp" line="179"/>
+        <location filename="gamefalloutnv.cpp" line="165"/>
         <source>Fallout NV Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutnv.cpp" line="189"/>
+        <location filename="gamefalloutnv.cpp" line="175"/>
         <source>Adds support for the game Fallout New Vegas</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -244,11 +244,7 @@ QString GameFalloutNV::steamAPPId() const
 
 QStringList GameFalloutNV::primaryPlugins() const
 {
-  return {
-      "falloutnv.esm", "DeadMoney.esm", "HonestHearts.esm", "OldWorldBlues.esm",
-      "LonesomeRoad.esm", "GunRunnersArsenal.esm", "ClassicPack.esm",
-      "MercenaryPack.esm", "TribalPack.esm", "CaravanPack.esm"
-  };
+  return { "falloutnv.esm" };
 }
 
 QStringList GameFalloutNV::gameVariants() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -149,6 +149,8 @@ QList<ExecutableInfo> GameFalloutNV::executables() const
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
       QList<ExecutableInfo>()
+      << ExecutableInfo("Fallout Mod Manager", findInGameFolder("fomm/fomm.exe"))
+      << ExecutableInfo("BOSS", findInGameFolder("BOSS/BOSS.exe"))
       << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
       << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
              .withArgument("--game=\"FalloutNV\"");

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -149,7 +149,7 @@ QList<ExecutableInfo> GameFalloutNV::executables() const
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
       QList<ExecutableInfo>()
-      << ExecutableInfo("Construction Kit", findInGameFolder("geck.exe"))
+      << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
       << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
              .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -148,12 +148,13 @@ QList<ExecutableInfo> GameFalloutNV::executables() const
   ExecutableInfo game("New Vegas", findInGameFolder(binaryName()));
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
-      QList<ExecutableInfo>()
-      << ExecutableInfo("Fallout Mod Manager", findInGameFolder("fomm/fomm.exe"))
-      << ExecutableInfo("BOSS", findInGameFolder("BOSS/BOSS.exe"))
-      << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
-      << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
-             .withArgument("--game=\"FalloutNV\"");
+      QList<ExecutableInfo>() << ExecutableInfo("Fallout Mod Manager",
+                                                findInGameFolder("fomm/fomm.exe"))
+                              << ExecutableInfo("BOSS",
+                                                findInGameFolder("BOSS/BOSS.exe"))
+                              << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
+                              << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
+                                     .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {
     extraExecutables.prepend(ExecutableInfo(
         "NVSE", findInGameFolder(feature<ScriptExtender>()->loaderName())));

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -244,7 +244,11 @@ QString GameFalloutNV::steamAPPId() const
 
 QStringList GameFalloutNV::primaryPlugins() const
 {
-  return {"falloutnv.esm"};
+  return {
+      "falloutnv.esm", "DeadMoney.esm", "HonestHearts.esm", "OldWorldBlues.esm",
+      "LonesomeRoad.esm", "GunRunnersArsenal.esm", "ClassicPack.esm",
+      "MercenaryPack.esm", "TribalPack.esm", "CaravanPack.esm"
+  };
 }
 
 QStringList GameFalloutNV::gameVariants() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -244,7 +244,7 @@ QString GameFalloutNV::steamAPPId() const
 
 QStringList GameFalloutNV::primaryPlugins() const
 {
-  return { "falloutnv.esm" };
+  return {"falloutnv.esm"};
 }
 
 QStringList GameFalloutNV::gameVariants() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -149,9 +149,7 @@ QList<ExecutableInfo> GameFalloutNV::executables() const
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
       QList<ExecutableInfo>()
-      << ExecutableInfo("Fallout Mod Manager", findInGameFolder("fomm/fomm.exe"))
       << ExecutableInfo("Construction Kit", findInGameFolder("geck.exe"))
-      << ExecutableInfo("BOSS", findInGameFolder("BOSS/BOSS.exe"))
       << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
              .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {


### PR DESCRIPTION
# Motivations
GECK is a more accurate name for the Fallout specific creation kit

# Modifications
- Rename Construction Kit to GECK, which is more well known
