### PR TITLE
Add setting to disable/enable LOOT

### DIFF
--- a/src/game_falloutNV_en.ts
+++ b/src/game_falloutNV_en.ts
@@ -4,13 +4,18 @@
 <context>
     <name>GameFalloutNV</name>
     <message>
-        <location filename="gamefalloutnv.cpp" line="165"/>
+        <location filename="gamefalloutnv.cpp" line="182"/>
         <source>Fallout NV Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutnv.cpp" line="175"/>
+        <location filename="gamefalloutnv.cpp" line="192"/>
         <source>Adds support for the game Fallout New Vegas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamefalloutnv.cpp" line="204"/>
+        <source>While not recommended by the FNV modding community, enables LOOT sorting</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -125,7 +125,7 @@ bool GameFalloutNV::isInstalled() const
 
 QString GameFalloutNV::gameName() const
 {
-  return "New Vegas";
+  return "Fallout New Vegas";
 }
 
 QString GameFalloutNV::gameDirectoryName() const
@@ -199,7 +199,11 @@ MOBase::VersionInfo GameFalloutNV::version() const
 
 QList<PluginSetting> GameFalloutNV::settings() const
 {
-  return QList<PluginSetting>();
+  return QList<PluginSetting>()
+         << PluginSetting("enable_loot_sorting",
+                          tr("While not recommended by the FNV modding community, "
+                             "enables LOOT sorting"),
+                          false);
 }
 
 void GameFalloutNV::initializeProfile(const QDir& path, ProfileSettings settings) const
@@ -281,6 +285,13 @@ QStringList GameFalloutNV::DLCPlugins() const
   return {"DeadMoney.esm",    "HonestHearts.esm",      "OldWorldBlues.esm",
           "LonesomeRoad.esm", "GunRunnersArsenal.esm", "CaravanPack.esm",
           "ClassicPack.esm",  "MercenaryPack.esm",     "TribalPack.esm"};
+}
+
+MOBase::IPluginGame::SortMechanism GameFalloutNV::sortMechanism() const
+{
+  if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
+    return IPluginGame::SortMechanism::LOOT;
+  return IPluginGame::SortMechanism::NONE;
 }
 
 int GameFalloutNV::nexusModOrganizerID() const

--- a/src/gamefalloutnv.cpp
+++ b/src/gamefalloutnv.cpp
@@ -125,7 +125,7 @@ bool GameFalloutNV::isInstalled() const
 
 QString GameFalloutNV::gameName() const
 {
-  return "Fallout New Vegas";
+  return "New Vegas";
 }
 
 QString GameFalloutNV::gameDirectoryName() const

--- a/src/gamefalloutnv.h
+++ b/src/gamefalloutnv.h
@@ -34,6 +34,7 @@ public:  // IPluginGame interface
   virtual QString gameNexusName() const override;
   virtual QStringList iniFiles() const override;
   virtual QStringList DLCPlugins() const override;
+  virtual SortMechanism sortMechanism() const override;
   virtual int nexusModOrganizerID() const override;
   virtual int nexusGameID() const override;
 


### PR DESCRIPTION
# Motivations
This plugin has been missing a sortMechanism definition for awhile which appears to cause LOOT to always be enabled, and generally it's recommended in the FNV modding community not to use LOOT

# Modifications
- Add a plugin setting to enable/disable the LOOT sort button, default it to false