### PR TITLE
Add `RaceMenuPresets` to possible data folders

### DIFF
--- a/src/falloutnvmoddatachecker.h
+++ b/src/falloutnvmoddatachecker.h
@@ -38,7 +38,6 @@ protected:
                               "config",
                               "KEYWORDS",
                               "BaseObjectSwapper",
-                              "Root",
                               "RaceMenuPresets"};
     return result;
   }

--- a/src/falloutnvmoddatachecker.h
+++ b/src/falloutnvmoddatachecker.h
@@ -11,15 +11,35 @@ public:
 protected:
   virtual const FileNameSet& possibleFolderNames() const override
   {
-    static FileNameSet result{"fonts",      "interface",     "menus",
-                              "meshes",     "music",         "scripts",
-                              "shaders",    "sound",         "strings",
-                              "textures",   "trees",         "video",
-                              "facegen",    "materials",     "nvse",
-                              "distantlod", "asi",           "Tools",
-                              "MCM",        "distantland",   "mits",
-                              "dllplugins", "CalienteTools", "shadersfx",
-                              "config",     "KEYWORDS",      "BaseObjectSwapper"};
+    static FileNameSet result{"fonts",
+                              "interface",
+                              "menus",
+                              "meshes",
+                              "music",
+                              "scripts",
+                              "shaders",
+                              "sound",
+                              "strings",
+                              "textures",
+                              "trees",
+                              "video",
+                              "facegen",
+                              "materials",
+                              "nvse",
+                              "distantlod",
+                              "asi",
+                              "Tools",
+                              "MCM",
+                              "distantland",
+                              "mits",
+                              "dllplugins",
+                              "CalienteTools",
+                              "shadersfx",
+                              "config",
+                              "KEYWORDS",
+                              "BaseObjectSwapper",
+                              "Root",
+                              "RaceMenuPresets"};
     return result;
   }
   virtual const FileNameSet& possibleFileExtensions() const override


### PR DESCRIPTION
# Motivations
- `RaceMenuPresets` is a data directory used by a popular mod for FNV Character Preset Menu https://www.nexusmods.com/newvegas/mods/72789

# Modifications
- Add `RaceMenuPresets` to the list of possible data folder names
- Run clang-format against the header file